### PR TITLE
perf(Collection): Better Arr::flatten

### DIFF
--- a/src/collection/src/Arr.php
+++ b/src/collection/src/Arr.php
@@ -166,10 +166,14 @@ class Arr
             $item = $item instanceof Collection ? $item->all() : $item;
             if (! is_array($item)) {
                 $result[] = $item;
-            } elseif ($depth === 1) {
-                $result = array_merge($result, array_values($item));
             } else {
-                $result = array_merge($result, static::flatten($item, $depth - 1));
+                $values = $depth === 1
+                    ? array_values($item)
+                    : static::flatten($item, $depth - 1);
+
+                foreach ($values as $value) {
+                    $result[] = $value;
+                }
             }
         }
         return $result;


### PR DESCRIPTION
## Benchmark
```php
$source = [];
$exampleItem = ['a','b','c','d','e','f','g','h']; // 8
for ($i=0; $i<5000; $i++){
    $source[] = $exampleItem;
}
$start = microtime(true);
\Hyperf\Collection\collect($source)->flatten();
var_dump('cost: ' . microtime(true) - $start); // original: 0.21s, now: 0.001s
```